### PR TITLE
Add strict compatibility requirements for Node versions >=11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "cypress": "5.0.0 - 6",
     "lodash": "^4.17.15",
     "yargs": "^15.3.1"
+  },
+  "engineStrict": true,
+  "engines": {
+    "node": ">= 11.0.0"
   }
 }


### PR DESCRIPTION
These changes add a minimum version requirement for Node version 11.0.0
and higher, since the `Array#flat` method requires such.

This addresses issue #8 on GitHub.