### PR TITLE
Add reporter option

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,13 @@ var argv = yargs.scriptName('cypress-utils')
     description: 'Glob pattern of the test files to load',
     global: true,
   })
+  .option('reporter', {
+    alias: ['r', 'reporter'],
+    type: 'string',
+    description: 'Reporter that will be used',
+    default: 'list',
+    global: true,
+  })
   .help()
   .alias('help', 'h')
   .demandCommand()
@@ -76,7 +83,7 @@ async function createTestSample(specIdentifiers) {
       config: cypressConfig,
       configFile: argv.configFile,
       spec: castArray(specIdentifiers).join(','),
-      reporter: 'list',
+      reporter: argv.reporter,
       quiet: true,
     });
     return results;


### PR DESCRIPTION
Hi @trentrand. I need the option to use the reporter we use when using the utils. It's a pretty simple addition 👍 

You can now select reporter by adding `-r ${reporter}`
