### PR TITLE
Move cypress to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,58 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@cypress/listr-verbose-renderer": {
-      "version": "0.4.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
-      "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
-      "requires": {
-        "chalk": "^1.1.3",
-        "cli-cursor": "^1.0.2",
-        "date-fns": "^1.27.2",
-        "figures": "^1.7.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
     "@cypress/request": {
       "version": "2.88.5",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/@cypress/request/-/request-2.88.5.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/@cypress/request/-/request-2.88.5.tgz",
       "integrity": "sha1-jX7NF7U6hJz9WrBtWr59hJdjddc=",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -81,8 +34,9 @@
     },
     "@cypress/xvfb": {
       "version": "1.2.4",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/@cypress/xvfb/-/xvfb-1.2.4.tgz",
       "integrity": "sha1-La9C6CdbOfSqU8FCFOVXvRTndIo=",
+      "dev": true,
       "requires": {
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
@@ -90,20 +44,13 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/debug/-/debug-3.2.7.tgz",
+          "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/debug/-/debug-3.2.7.tgz",
           "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         }
-      }
-    },
-    "@samverschueren/stream-to-observable": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
-      "integrity": "sha1-ohEXsZ7pvnDDeewYd1N+8uHGMwE=",
-      "requires": {
-        "any-observable": "^0.3.0"
       }
     },
     "@types/color-name": {
@@ -111,20 +58,49 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/node": {
+      "version": "14.17.9",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/@types/node/-/node-14.17.9.tgz",
+      "integrity": "sha1-uXwFfmE4rbe3IN8r0CZLA8n1BP0=",
+      "dev": true
+    },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-      "integrity": "sha1-OoTPXsMklDkBXhQEm9MWFBm/nq4="
+      "version": "6.0.3",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
+      "integrity": "sha1-ed9vNYro955ij+NaY2CKDqjnzwg=",
+      "dev": true
     },
     "@types/sizzle": {
-      "version": "2.3.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha1-qBG4wY4rq6t9VCszZYh64uTZ3kc="
+      "version": "2.3.3",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha1-/14vGQKWnTBSJaBHyKD9XJFc6+8=",
+      "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.2",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha1-xI5dVq/xREQJ45+hZLC01FUqe3o=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
     },
     "ajv": {
       "version": "6.12.6",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ajv/-/ajv-6.12.6.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -132,10 +108,20 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+      "dev": true
+    },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s="
+      "version": "4.3.2",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.21.3"
+      }
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -151,28 +137,32 @@
         "color-convert": "^2.0.1"
       }
     },
-    "any-observable": {
-      "version": "0.3.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/any-observable/-/any-observable-0.3.0.tgz",
-      "integrity": "sha1-r5M0deWAamfQ198JDdXovvZdEZs="
-    },
     "arch": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha1-G8R4GPMFdk8jqzMGsL/AhsWinRE="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha1-G8R4GPMFdk8jqzMGsL/AhsWinRE=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=",
+      "dev": true
     },
     "async": {
       "version": "3.2.0",
@@ -181,23 +171,27 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha1-YCzUtG6EStTv/JKoARo8RuAjjcI="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha1-YCzUtG6EStTv/JKoARo8RuAjjcI=",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.11.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -206,21 +200,24 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
     "blob-util": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/blob-util/-/blob-util-2.0.2.tgz",
-      "integrity": "sha1-O048KBERu38REoUYAGzcYLQDoes="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/blob-util/-/blob-util-2.0.2.tgz",
+      "integrity": "sha1-O048KBERu38REoUYAGzcYLQDoes=",
+      "dev": true
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -233,18 +230,15 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "cachedir": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/cachedir/-/cachedir-2.3.0.tgz",
-      "integrity": "sha1-DHWJKgUhmPCyHHwYBNgzHt/K4Og="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/cachedir/-/cachedir-2.3.0.tgz",
+      "integrity": "sha1-DHWJKgUhmPCyHHwYBNgzHt/K4Og=",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -253,40 +247,63 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
+      "version": "4.1.2",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "check-more-types": {
       "version": "2.24.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
     },
     "ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y="
+      "version": "3.2.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha1-KHbLlIpJh5e1I28AlbwFfQ3KOLY=",
+      "dev": true
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+      "dev": true
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "version": "3.1.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
+      "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-table3": {
       "version": "0.6.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/cli-table3/-/cli-table3-0.6.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/cli-table3/-/cli-table3-0.6.0.tgz",
       "integrity": "sha1-t7G8ZcqOe1zvkSThPcKyHizk+u4=",
+      "dev": true,
       "requires": {
         "colors": "^1.1.2",
         "object-assign": "^4.1.0",
@@ -294,45 +311,13 @@
       }
     },
     "cli-truncate": {
-      "version": "0.2.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/cli-truncate/-/cli-truncate-0.2.1.tgz",
-      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "version": "2.1.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha1-w54ovwXtzeW+O5iZKiLe7Vork8c=",
+      "dev": true,
       "requires": {
-        "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
       }
     },
     "cliui": {
@@ -344,11 +329,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
       }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -363,55 +343,56 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ=",
+      "dev": true
+    },
     "colors": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/colors/-/colors-1.4.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/colors/-/colors-1.4.0.tgz",
       "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g=",
+      "dev": true,
       "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha1-Rqu9FlL44Fm92u+Zu9yyrZzxea4="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha1-Rqu9FlL44Fm92u+Zu9yyrZzxea4=",
+      "dev": true
     },
     "common-tags": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha1-jjFT5ULUo56bEFVENK+q+YlWqTc="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha1-jjFT5ULUo56bEFVENK+q+YlWqTc=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -419,69 +400,92 @@
       }
     },
     "cypress": {
-      "version": "6.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/cypress/-/cypress-6.0.0.tgz",
-      "integrity": "sha1-VwUHc8Yej+HlyYccwDTGFvys3tk=",
+      "version": "8.3.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/cypress/-/cypress-8.3.0.tgz",
+      "integrity": "sha1-upBtIXCIgHOtlLK+G5lKdJu7fH0=",
+      "dev": true,
       "requires": {
-        "@cypress/listr-verbose-renderer": "^0.4.1",
         "@cypress/request": "^2.88.5",
         "@cypress/xvfb": "^1.2.4",
-        "@types/sinonjs__fake-timers": "^6.0.1",
+        "@types/node": "^14.14.31",
+        "@types/sinonjs__fake-timers": "^6.0.2",
         "@types/sizzle": "^2.3.2",
-        "arch": "^2.1.2",
-        "blob-util": "2.0.2",
+        "arch": "^2.2.0",
+        "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
+        "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.0",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
-        "debug": "^4.1.1",
-        "eventemitter2": "^6.4.2",
-        "execa": "^4.0.2",
+        "dayjs": "^1.10.4",
+        "debug": "^4.3.2",
+        "enquirer": "^2.3.6",
+        "eventemitter2": "^6.4.3",
+        "execa": "4.1.0",
         "executable": "^4.1.1",
-        "extract-zip": "^1.7.0",
-        "fs-extra": "^9.0.1",
+        "extract-zip": "2.0.1",
+        "figures": "^3.2.0",
+        "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.3.2",
+        "is-ci": "^3.0.0",
+        "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
-        "listr": "^0.14.3",
-        "lodash": "^4.17.19",
+        "listr2": "^3.8.3",
+        "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
-        "moment": "^2.27.0",
         "ospath": "^1.2.2",
-        "pretty-bytes": "^5.4.1",
-        "ramda": "~0.26.1",
+        "pretty-bytes": "^5.6.0",
+        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
-        "supports-color": "^7.2.0",
+        "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "url": "^0.11.0",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+          "dev": true
+        }
       }
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
-    "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha1-LnG/CxGRU9u0zE6I2epaz7UNwFw="
+    "dayjs": {
+      "version": "1.10.6",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha1-KIsqqC8thBimydTfWJjAc3rQKmM=",
+      "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
+      "version": "4.3.2",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
       }
     },
     "decamelize": {
@@ -491,22 +495,19 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
-    },
-    "elegant-spinner": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -515,26 +516,39 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha1-Kn/l3WNKHkElqXXsmU/1RW3Dc00=",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eventemitter2": {
-      "version": "6.4.3",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/eventemitter2/-/eventemitter2-6.4.3.tgz",
-      "integrity": "sha1-NcVjYZsT82gefrBcva9Q9WuliCA="
+      "version": "6.4.4",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/eventemitter2/-/eventemitter2-6.4.4.tgz",
+      "integrity": "sha1-qpboJ1xNvrAXpdDgN4DGVhKhICs=",
+      "dev": true
     },
     "execa": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/execa/-/execa-4.1.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/execa/-/execa-4.1.0.tgz",
       "integrity": "sha1-TlSRrRVy8vF6d9OIxshXE1sihHo=",
+      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -545,92 +559,69 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2",
         "strip-final-newline": "^2.0.0"
-      },
-      "dependencies": {
-        "onetime": {
-          "version": "5.1.2",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/onetime/-/onetime-5.1.2.tgz",
-          "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        }
       }
     },
     "executable": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/executable/-/executable-4.1.1.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/executable/-/executable-4.1.1.tgz",
       "integrity": "sha1-QVMr/zYdPlevTXY7cFgtsY9dEzw=",
+      "dev": true,
       "requires": {
         "pify": "^2.2.0"
       }
     },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-    },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
     },
     "extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha1-VWzDrp339FLEk6DPtRzDAneUCSc=",
+      "version": "2.0.1",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=",
+      "dev": true,
       "requires": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+      "dev": true
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "version": "3.2.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
+      "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "find-up": {
@@ -644,13 +635,15 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -658,14 +651,15 @@
       }
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha1-kQ2gBiQ3ukw5/t2GPxZ1zP78ufw=",
+      "version": "9.1.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha1-WVRGDHZKjaIJS6NVS/g55rmnyG0=",
+      "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -680,24 +674,27 @@
     },
     "get-stream": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/get-stream/-/get-stream-5.2.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
     },
     "getos": {
       "version": "3.2.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/getos/-/getos-3.2.1.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/getos/-/getos-3.2.1.tgz",
       "integrity": "sha1-ATTR9OAOtGFExanArE3Ah8uyfcU=",
+      "dev": true,
       "requires": {
         "async": "^3.2.0"
       }
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -716,56 +713,47 @@
       }
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha1-rN87tmhbzVXLNeigUiZlaelGkgE=",
+      "version": "3.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/global-dirs/-/global-dirs-3.0.0.tgz",
+      "integrity": "sha1-cKdv6E6jFas3sfVXbL3n1I73JoY=",
+      "dev": true,
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "2.0.0"
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs="
+      "version": "4.2.8",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo=",
+      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.5",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/har-validator/-/har-validator-5.1.5.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        }
-      }
-    },
     "has-flag": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -774,13 +762,15 @@
     },
     "human-signals": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M=",
+      "dev": true
     },
     "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+      "version": "4.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -797,16 +787,18 @@
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "version": "2.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha1-5f1Vbs3VcmvpePoQAYYurLCpS8U=",
+      "dev": true
     },
     "is-ci": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
+      "version": "3.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/is-ci/-/is-ci-3.0.0.tgz",
+      "integrity": "sha1-x+e+PJ2O730PoUQ5C9HkuI3EyZQ=",
+      "dev": true,
       "requires": {
-        "ci-info": "^2.0.0"
+        "ci-info": "^3.1.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -815,97 +807,90 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-installed-globally": {
-      "version": "0.3.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-      "integrity": "sha1-/T76ee5nDRGHIzGC1bCh3QAxMUE=",
+      "version": "0.4.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha1-mg/UB5ScMPhutpWe8beZTtC3tSA=",
+      "dev": true,
       "requires": {
-        "global-dirs": "^2.0.1",
-        "is-path-inside": "^3.0.1"
-      }
-    },
-    "is-observable": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-observable/-/is-observable-1.1.0.tgz",
-      "integrity": "sha1-s+mGyPRN6VCGfKtUA/WjRlAFl14=",
-      "requires": {
-        "symbol-observable": "^1.1.0"
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
       }
     },
     "is-path-inside": {
-      "version": "3.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc="
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha1-OauVnMv5p3TPB597QMeib3YxNfE="
+      "version": "3.0.3",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
+      "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM="
+      "version": "2.0.1",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/jsonfile/-/jsonfile-6.1.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha1-vFWyY0eTxnnsZAMJTrE2mKbsCq4=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc="
-        }
       }
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -915,188 +900,34 @@
     },
     "lazy-ass": {
       "version": "1.6.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
     },
-    "listr": {
-      "version": "0.14.3",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/listr/-/listr-0.14.3.tgz",
-      "integrity": "sha1-L+qQlgTkNL5GTFC926DUlpKPpYY=",
+    "listr2": {
+      "version": "3.11.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/listr2/-/listr2-3.11.0.tgz",
+      "integrity": "sha1-l3GwJAeHWqeOc9bg/2VBu+wKruk=",
+      "dev": true,
       "requires": {
-        "@samverschueren/stream-to-observable": "^0.3.0",
-        "is-observable": "^1.1.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.5.0",
-        "listr-verbose-renderer": "^0.5.0",
-        "p-map": "^2.0.0",
-        "rxjs": "^6.3.3"
+        "cli-truncate": "^2.1.0",
+        "colorette": "^1.2.2",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rxjs": "^6.6.7",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        }
-      }
-    },
-    "listr-silent-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
-    },
-    "listr-update-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-      "integrity": "sha1-Tqg2hUinuK7LfgbYyVy0WuLt5qI=",
-      "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^2.3.0",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+          "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "requires": {
-            "chalk": "^1.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "listr-verbose-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-      "integrity": "sha1-8RMhZ1NepMEmEQK58o2sfLoeA9s=",
-      "requires": {
-        "chalk": "^2.4.1",
-        "cli-cursor": "^2.1.0",
-        "date-fns": "^1.27.2",
-        "figures": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-          "requires": {
-            "has-flag": "^3.0.0"
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -1116,117 +947,71 @@
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
     },
     "log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha1-abPMRtIPRI7M23XqH6cz2eghySA=",
+      "version": "4.1.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+      "dev": true,
       "requires": {
-        "chalk": "^4.0.0"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       }
     },
     "log-update": {
-      "version": "2.3.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/log-update/-/log-update-2.3.0.tgz",
-      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "version": "4.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha1-WJ7NNSRx8qHAxXAodUOmTf0g4KE=",
+      "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "cli-cursor": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
+        "slice-ansi": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha1-UA6N0P1VsFgVCGJVsxla3ypF/ms=",
+          "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0"
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
           }
         }
       }
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "dev": true
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I="
+      "version": "1.49.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha1-89/eYMmenPO8lwHWh3ePU3ABy+0=",
+      "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
+      "version": "2.1.32",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha1-HQDonn3n/gIAjbYQAdngKFJnD9U=",
+      "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.49.0"
       }
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1238,49 +1023,36 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "dev": true
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+      "version": "2.1.3",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "dev": true
     },
     "npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+      "dev": true,
       "requires": {
         "path-key": "^3.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -1291,14 +1063,19 @@
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+      "version": "5.1.2",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
     },
     "ospath": {
       "version": "1.2.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ospath/-/ospath-1.2.2.tgz",
-      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ospath/-/ospath-1.2.2.tgz",
+      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -1317,9 +1094,13 @@
       }
     },
     "p-map": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU="
+      "version": "4.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha1-uy+Vpe2i7BaOySdOBqdHw+KQTSs=",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
     },
     "p-try": {
       "version": "2.2.0",
@@ -1338,43 +1119,45 @@
     },
     "path-key": {
       "version": "3.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+      "dev": true
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pretty-bytes": {
-      "version": "5.4.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-      "integrity": "sha1-zYn3m7zvIePSHrDaaP/pP4A+iEs="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+      "version": "5.6.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha1-NWJW9kOAR3PIL2RyP+eMksYr6us=",
+      "dev": true
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -1382,49 +1165,33 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha1-jUE1HrgRHFU1Nhf8O7/62OTTXQY="
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        }
-      }
+      "version": "0.27.1",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha1-Zvwt8++HOHT/wtpqqJhGWKus9ck=",
+      "dev": true
     },
     "request-progress": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/request-progress/-/request-progress-3.0.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/request-progress/-/request-progress-3.0.0.tgz",
       "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+      "dev": true,
       "requires": {
         "throttleit": "^1.0.0"
       }
@@ -1440,39 +1207,44 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "version": "3.1.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
+      "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/rimraf/-/rimraf-3.0.2.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
     },
     "rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha1-jKhGNcTaqQDA05Z6buesYCce5VI=",
+      "version": "6.6.7",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1481,31 +1253,41 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+      "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+      "version": "3.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha1-Md3BCTCht+C2ewjJbC9Jt3p4l4c=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -1528,21 +1310,6 @@
         "strip-ansi": "^6.0.0"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        }
-      }
-    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -1553,39 +1320,45 @@
     },
     "strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
+      "dev": true
     },
     "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+      "version": "8.1.1",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ="
-    },
     "throttleit": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "tmp": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/tmp/-/tmp-0.2.1.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha1-hFf8MDfc9HGcJRNnoa9lAO4czxQ=",
+      "dev": true,
       "requires": {
         "rimraf": "^3.0.0"
       }
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -1593,49 +1366,57 @@
     },
     "tslib": {
       "version": "1.14.1",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    "type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
+      "dev": true
     },
     "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha1-thodoXPoQ1sv48Z9Kbmt+FlL0W0="
+      "version": "2.0.0",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
+      "dev": true
     },
     "untildify": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha1-K8lHuVNlJIfkYAlJ+wkeOujNkZs="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha1-K8lHuVNlJIfkYAlJ+wkeOujNkZs=",
+      "dev": true
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
+      "version": "4.4.1",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/url/-/url-0.11.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -1643,25 +1424,23 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+          "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
         }
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
     "uuid": {
       "version": "3.4.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -1670,8 +1449,9 @@
     },
     "which": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/which/-/which-2.0.2.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -1730,8 +1510,9 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "https://artifactory.squarespace.net/api/npm/npm-all/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://artifactory.squarespace.net:443/artifactory/api/npm/npm-all/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,14 @@
     "url": "https://github.com/trentrand/cypress-utils/issues"
   },
   "homepage": "https://github.com/trentrand/cypress-utils#readme",
+  "peerDependencies": {
+    "cypress": ">=5 <=8"
+  },
+  "devDependencies": {
+    "cypress": "8.3.0"
+  },
   "dependencies": {
     "async": "^3.2.0",
-    "cypress": "5.0.0 - 6",
     "glob": "^7.1.6",
     "lodash": "^4.17.15",
     "yargs": "^15.3.1"


### PR DESCRIPTION
This PR moves Cypress to `peerDependencies` instead of `dependencies`, to give consumers more control over the cypress version used with this library, and to protect against multiple copies of cypress being installed into a consuming application