### PR TITLE
19/custom browser option

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,13 +62,6 @@ var argv = yargs.scriptName('cypress-utils')
     description: 'Glob pattern of the test files to load',
     global: true,
   })
-  .option('reporter', {
-    alias: ['r'],
-    type: 'string',
-    description: 'Reporter that will be used',
-    default: 'list',
-    global: true,
-  })
   .help()
   .alias('help', 'h')
   .demandCommand()
@@ -83,7 +76,6 @@ async function createTestSample(specIdentifiers) {
       config: cypressConfig,
       configFile: argv.configFile,
       spec: castArray(specIdentifiers).join(','),
-      reporter: argv.reporter,
       quiet: true,
     });
     return results;

--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ var argv = yargs.scriptName('cypress-utils')
   .help()
   .alias('help', 'h')
   .demandCommand()
-  .strict()
   .showHelpOnFail(true)
   .wrap(Math.min(120, yargs.terminalWidth))
   .argv
@@ -80,6 +79,7 @@ var argv = yargs.scriptName('cypress-utils')
 async function createTestSample(specIdentifiers) {
   try {
     const results = await cypress.run({
+      ...argv,
       config: cypressConfig,
       configFile: argv.configFile,
       spec: castArray(specIdentifiers).join(','),


### PR DESCRIPTION
**Allow unrecognized CLI options to pass-through to Cypress** 

> These changes remove the strict option checking, allowing unrecognized
command line options to be accepted as valid input.

> This allows flags like `--reporter` and `--browser` to be specified
without requiring that the script is continually updated for each
desired option.

> This fixes the issue raised in Issue #19.

**Remove explicit declaration of --reporter command-line option** 

> Now that all unrecognized command-line options are accepted and
passed-through to the Cypress CLI, there's no need to explicitly handle
reporter.